### PR TITLE
Require app approval for Calendar and Reminders mutations

### DIFF
--- a/Foundation Lab/AppIntents/ManageRemindersIntent.swift
+++ b/Foundation Lab/AppIntents/ManageRemindersIntent.swift
@@ -2,6 +2,7 @@ import AppIntents
 import Foundation
 import FoundationLabCore
 import FoundationModelsKit
+import FoundationModelsTools
 
 struct ManageRemindersIntent: AppIntent {
     static let title: LocalizedStringResource = "Manage Reminders"
@@ -17,7 +18,14 @@ struct ManageRemindersIntent: AppIntent {
     var prompt: String
 
     func perform() async throws -> some IntentResult & ReturnsValue<String> {
-        let response = try await ManageRemindersUseCase().execute(
+        let confirmation = ToolMutationConfirmationHandler { request in
+            try await confirm(request)
+        }
+        let response = try await ManageRemindersUseCase(
+            manager: FoundationModelsReminderManager(
+                mutationConfirmation: confirmation
+            )
+        ).execute(
             ManageRemindersRequest(
                 mode: .customPrompt,
                 customPrompt: prompt,
@@ -31,5 +39,40 @@ struct ManageRemindersIntent: AppIntent {
         )
 
         return .result(value: response.content)
+    }
+
+    private func confirm(_ request: ToolMutationRequest) async throws -> ToolMutationDecision {
+        try await requestConfirmation(
+            actionName: confirmationAction(for: request),
+            dialog: confirmationDialog(for: request)
+        )
+        return .approved()
+    }
+
+    private func confirmationAction(for request: ToolMutationRequest) -> ConfirmationActionName {
+        if request.isDestructive {
+            return .custom(
+                acceptLabel: "Delete",
+                acceptAlternatives: [],
+                denyLabel: "Cancel",
+                denyAlternatives: [],
+                destructive: true
+            )
+        }
+
+        return request.action == "create" ? .create : .continue
+    }
+
+    private func confirmationDialog(for request: ToolMutationRequest) -> IntentDialog {
+        let details = request.details
+            .map { "\($0.label): \($0.value)" }
+            .joined(separator: "\n")
+        let supportingText = details.isEmpty
+            ? request.summary
+            : "\(request.summary)\n\(details)"
+        return IntentDialog(
+            full: "Proposed tool action",
+            supporting: "\(supportingText)"
+        )
     }
 }

--- a/Foundation Lab/Localizable.xcstrings
+++ b/Foundation Lab/Localizable.xcstrings
@@ -1,6 +1,326 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Action" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktion"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Action"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acción"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Action"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Azione"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "アクション"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "작업"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ação"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "操作"
+          }
+        }
+      }
+    },
+    "Approve" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Genehmigen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approve"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aprobar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approuver"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Approva"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "承認"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "승인"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aprovar"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "批准"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "核准"
+          }
+        }
+      }
+    },
+    "Delete" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Löschen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elimina"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "삭제"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Excluir"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刪除"
+          }
+        }
+      }
+    },
+    "Resource ID" : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ressourcen-ID"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resource ID"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID del recurso"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID de la ressource"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID risorsa"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "リソースID"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "리소스 ID"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ID do recurso"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "资源 ID"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資源 ID"
+          }
+        }
+      }
+    },
+    "This action deletes data and cannot be undone." : {
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Diese Aktion löscht Daten und kann nicht rückgängig gemacht werden."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This action deletes data and cannot be undone."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta acción elimina datos y no se puede deshacer."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cette action supprime des données et ne peut pas être annulée."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Questa azione elimina dati e non può essere annullata."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "この操作を行うとデータが削除され、元に戻せません。"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "이 작업은 데이터를 삭제하며 실행 취소할 수 없습니다."
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Esta ação exclui dados e não pode ser desfeita."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作会删除数据，且无法撤销。"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "此操作會刪除資料，且無法還原。"
+          }
+        }
+      }
+    },
     "@Generable Pattern" : {
       "localizations" : {
         "de" : {

--- a/Foundation Lab/Models/ToolMutationApprovalCoordinator.swift
+++ b/Foundation Lab/Models/ToolMutationApprovalCoordinator.swift
@@ -1,0 +1,108 @@
+import Foundation
+import FoundationModelsTools
+import Observation
+
+@MainActor
+@Observable
+final class ToolMutationApprovalCoordinator {
+    private(set) var currentRequest: ToolMutationRequest?
+
+    var isPresentingRequest: Bool {
+        get { currentRequest != nil }
+        set {
+            if !newValue {
+                denyCurrentRequest()
+            }
+        }
+    }
+
+    @ObservationIgnored private var activeRequest: PendingRequest?
+    @ObservationIgnored private var queuedRequests = [PendingRequest]()
+
+    func confirmation(for request: ToolMutationRequest) async throws -> ToolMutationDecision {
+        try await withTaskCancellationHandler {
+            try Task.checkCancellation()
+            return try await withCheckedThrowingContinuation { continuation in
+                enqueue(request, continuation: continuation)
+            }
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancel(requestID: request.id)
+            }
+        }
+    }
+
+    func approveCurrentRequest() {
+        resolveCurrentRequest(with: .approved())
+    }
+
+    func denyCurrentRequest() {
+        resolveCurrentRequest(
+            with: .denied(reason: String(localized: "Denied by the user"))
+        )
+    }
+
+    func cancelAll() {
+        let requests = [activeRequest].compactMap { $0 } + queuedRequests
+        activeRequest = nil
+        queuedRequests.removeAll()
+        currentRequest = nil
+        requests.forEach { $0.continuation.resume(throwing: CancellationError()) }
+    }
+
+    private func enqueue(
+        _ request: ToolMutationRequest,
+        continuation: CheckedContinuation<ToolMutationDecision, any Error>
+    ) {
+        let pendingRequest = PendingRequest(
+            request: request,
+            continuation: continuation
+        )
+        guard activeRequest == nil else {
+            queuedRequests.append(pendingRequest)
+            return
+        }
+
+        present(pendingRequest)
+    }
+
+    private func resolveCurrentRequest(with decision: ToolMutationDecision) {
+        guard let activeRequest else { return }
+        self.activeRequest = nil
+        currentRequest = nil
+        activeRequest.continuation.resume(returning: decision)
+        presentNextRequest()
+    }
+
+    private func cancel(requestID: UUID) {
+        if activeRequest?.request.id == requestID {
+            guard let activeRequest else { return }
+            self.activeRequest = nil
+            currentRequest = nil
+            activeRequest.continuation.resume(throwing: CancellationError())
+            presentNextRequest()
+            return
+        }
+
+        guard let index = queuedRequests.firstIndex(where: { $0.request.id == requestID }) else {
+            return
+        }
+        let request = queuedRequests.remove(at: index)
+        request.continuation.resume(throwing: CancellationError())
+    }
+
+    private func presentNextRequest() {
+        guard !queuedRequests.isEmpty else { return }
+        present(queuedRequests.removeFirst())
+    }
+
+    private func present(_ request: PendingRequest) {
+        activeRequest = request
+        currentRequest = request.request
+    }
+}
+
+private struct PendingRequest {
+    let request: ToolMutationRequest
+    let continuation: CheckedContinuation<ToolMutationDecision, any Error>
+}

--- a/Foundation Lab/ViewModels/ChatViewModel.swift
+++ b/Foundation Lab/ViewModels/ChatViewModel.swift
@@ -9,6 +9,7 @@ import Foundation
 import FoundationLabCore
 import FoundationModels
 import FoundationModelsKit
+import FoundationModelsTools
 import Observation
 import Speech
 
@@ -31,6 +32,8 @@ final class ChatViewModel {
     @ObservationIgnored let permissionManager: PermissionManager
     @ObservationIgnored let speechSynthesizer: SpeechSynthesisService
     @ObservationIgnored let conversationEngine: FoundationModelConversationEngine
+    let toolMutationApprovalCoordinator: ToolMutationApprovalCoordinator
+    @ObservationIgnored private let toolMutationConfirmation: ToolMutationConfirmationHandler
     var isSummarizing: Bool = false
     var isApplyingWindow: Bool = false
     var sessionCount: Int = 1
@@ -125,10 +128,16 @@ final class ChatViewModel {
 
     init(
         permissionManager: PermissionManager? = nil,
-        speechSynthesizer: SpeechSynthesisService? = nil
+        speechSynthesizer: SpeechSynthesisService? = nil,
+        toolMutationApprovalCoordinator: ToolMutationApprovalCoordinator? = nil
     ) {
         self.permissionManager = permissionManager ?? PermissionManager()
         self.speechSynthesizer = speechSynthesizer ?? SpeechSynthesizer.shared
+        let approvalCoordinator = toolMutationApprovalCoordinator ?? ToolMutationApprovalCoordinator()
+        self.toolMutationApprovalCoordinator = approvalCoordinator
+        self.toolMutationConfirmation = ToolMutationConfirmationHandler { request in
+            try await approvalCoordinator.confirmation(for: request)
+        }
         let configuration = FoundationModelConversationConfiguration(
             baseInstructions: Self.defaultInstructions,
             summaryInstructions: """
@@ -242,7 +251,7 @@ extension ChatViewModel {
             modelRuntime: effectiveConfiguration.modelRuntime,
             reasoningLevel: effectiveConfiguration.reasoningLevel,
             guardrails: .default,
-            tools: selectedTools.map { $0.makeTool() }
+            tools: makeTools(for: selectedTools)
         )
         conversationEngine.setMaxContextSize(provisionalContextSize(for: effectiveConfiguration.modelRuntime))
         if effectiveConfiguration.modelRuntime == configuration.modelRuntime {
@@ -275,7 +284,7 @@ extension ChatViewModel {
             selectedTools.append(tool)
         }
 
-        conversationEngine.rebuild(tools: selectedTools.map { $0.makeTool() })
+        conversationEngine.rebuild(tools: makeTools(for: selectedTools))
         syncConversationState()
     }
 
@@ -288,6 +297,7 @@ extension ChatViewModel {
     }
 
     func cancelGeneration() {
+        toolMutationApprovalCoordinator.cancelAll()
         activeGenerationTask?.cancel()
         activeGenerationTask = nil
         activeGenerationID = nil
@@ -331,6 +341,12 @@ extension ChatViewModel {
         isSummarizing = conversationEngine.isSummarizing
         isApplyingWindow = conversationEngine.isApplyingWindow
         sessionCount = conversationEngine.sessionCount
+    }
+
+    private func makeTools(for selectedTools: [FoundationLabBuiltInTool]) -> [any Tool] {
+        selectedTools.flatMap {
+            $0.makeTools(mutationConfirmation: toolMutationConfirmation)
+        }
     }
 
     func fetchContextSize(for runtime: FoundationModelRuntime? = nil) async {

--- a/Foundation Lab/Views/Playground/ExperimentCodeGenerator.swift
+++ b/Foundation Lab/Views/Playground/ExperimentCodeGenerator.swift
@@ -3,14 +3,16 @@ import FoundationModelsKit
 
 enum ExperimentCodeGenerator {
     static func code(for configuration: FoundationLabExperimentConfiguration) -> String {
-        let tools = configuration.selectedTools.map(toolConstructor).joined(separator: ", ")
+        let tools = configuration.selectedTools.flatMap(toolConstructors).joined(separator: ", ")
         let model = modelDeclaration(for: configuration)
         let instructions = swiftLiteral(configuration.instructions)
         let prompt = swiftLiteral(configuration.prompt)
         let context = contextOptions(for: configuration)
         let options = generationOptions(for: configuration)
+        let toolSupport = toolSupportDeclarations(for: configuration.selectedTools)
         let experiment = """
         \(model)
+        \(toolSupport)
         let tools: [any Tool] = [\(tools)]
         let session = LanguageModelSession(
             model: model,
@@ -98,18 +100,51 @@ enum ExperimentCodeGenerator {
             : ""
     }
 
-    private static func toolConstructor(_ tool: FoundationLabBuiltInTool) -> String {
+    private static func toolConstructors(_ tool: FoundationLabBuiltInTool) -> [String] {
         switch tool {
-        case .weather: "WeatherTool()"
-        case .web: "Search1WebSearchTool()"
-        case .contacts: "ContactsTool()"
-        case .calendar: "CalendarTool()"
-        case .reminders: "RemindersTool()"
-        case .location: "LocationTool()"
-        case .health: "HealthTool()"
-        case .music: "MusicTool()"
-        case .webMetadata: "WebMetadataTool()"
+        case .weather: ["WeatherTool()"]
+        case .web: ["Search1WebSearchTool()"]
+        case .contacts: ["ContactsTool()"]
+        case .calendar:
+            [
+                "CalendarReadTool(service: calendarService)",
+                "CalendarMutationTool(service: calendarService, confirmation: mutationConfirmation)"
+            ]
+        case .reminders:
+            [
+                "RemindersReadTool(service: remindersService)",
+                "RemindersMutationTool(service: remindersService, confirmation: mutationConfirmation)"
+            ]
+        case .location: ["LocationTool()"]
+        case .health: ["HealthTool()"]
+        case .music: ["MusicTool()"]
+        case .webMetadata: ["WebMetadataTool()"]
         }
+    }
+
+    private static func toolSupportDeclarations(
+        for tools: [FoundationLabBuiltInTool]
+    ) -> String {
+        var declarations = [String]()
+
+        if tools.contains(where: { $0 == .calendar || $0 == .reminders }) {
+            declarations.append(
+                """
+                let mutationConfirmation = ToolMutationConfirmationHandler { request in
+                    print("Approval required: \\(request.summary)")
+                    return .denied(reason: "Connect this request to your app-owned confirmation UI.")
+                }
+                """
+            )
+        }
+        if tools.contains(.calendar) {
+            declarations.append("let calendarService = EventKitCalendarService()")
+        }
+        if tools.contains(.reminders) {
+            declarations.append("let remindersService = EventKitRemindersService()")
+        }
+
+        return declarations.joined(separator: "\n")
     }
 
     private static func swiftLiteral(_ value: String) -> String {

--- a/Foundation Lab/Views/Playground/PlaygroundView.swift
+++ b/Foundation Lab/Views/Playground/PlaygroundView.swift
@@ -147,13 +147,7 @@ struct PlaygroundView: View {
         }
 #endif
         .sheet(isPresented: $approvalCoordinator.isPresentingRequest) {
-            if let request = approvalCoordinator.currentRequest {
-                ToolMutationApprovalView(
-                    request: request,
-                    approve: approvalCoordinator.approveCurrentRequest,
-                    deny: approvalCoordinator.denyCurrentRequest
-                )
-            }
+            ToolMutationApprovalSheet(coordinator: approvalCoordinator)
         }
 #if os(iOS)
         .onChange(of: approvalCoordinator.isPresentingRequest) { _, isPresenting in

--- a/Foundation Lab/Views/Playground/PlaygroundView.swift
+++ b/Foundation Lab/Views/Playground/PlaygroundView.swift
@@ -27,6 +27,7 @@ struct PlaygroundView: View {
 
     var body: some View {
         @Bindable var viewModel = viewModel
+        @Bindable var approvalCoordinator = viewModel.toolMutationApprovalCoordinator
 
         VStack(spacing: 0) {
             PlaygroundHeaderView(
@@ -142,6 +143,22 @@ struct PlaygroundView: View {
         .sheet(isPresented: $showsSettings) {
             NavigationStack {
                 SettingsView()
+            }
+        }
+#endif
+        .sheet(isPresented: $approvalCoordinator.isPresentingRequest) {
+            if let request = approvalCoordinator.currentRequest {
+                ToolMutationApprovalView(
+                    request: request,
+                    approve: approvalCoordinator.approveCurrentRequest,
+                    deny: approvalCoordinator.denyCurrentRequest
+                )
+            }
+        }
+#if os(iOS)
+        .onChange(of: approvalCoordinator.isPresentingRequest) { _, isPresenting in
+            if isPresenting {
+                showsSettings = false
             }
         }
 #endif

--- a/Foundation Lab/Views/Playground/ToolMutationApprovalSheet.swift
+++ b/Foundation Lab/Views/Playground/ToolMutationApprovalSheet.swift
@@ -1,0 +1,25 @@
+//
+//  ToolMutationApprovalSheet.swift
+//  FoundationLab
+//
+
+import FoundationModelsTools
+import SwiftUI
+
+struct ToolMutationApprovalSheet: View {
+    @Bindable var coordinator: ToolMutationApprovalCoordinator
+
+    var body: some View {
+        Group {
+            if let request = coordinator.currentRequest {
+                ToolMutationApprovalView(
+                    request: request,
+                    approve: coordinator.approveCurrentRequest,
+                    deny: coordinator.denyCurrentRequest
+                )
+                // A queued request must never reuse the preceding approval view.
+                .id(request.id)
+            }
+        }
+    }
+}

--- a/Foundation Lab/Views/Playground/ToolMutationApprovalView.swift
+++ b/Foundation Lab/Views/Playground/ToolMutationApprovalView.swift
@@ -1,0 +1,68 @@
+import FoundationModelsTools
+import SwiftUI
+
+struct ToolMutationApprovalView: View {
+    let request: ToolMutationRequest
+    let approve: () -> Void
+    let deny: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Text(request.summary)
+                        .font(.body)
+
+                    LabeledContent("Tool", value: request.toolName)
+                    LabeledContent("Action", value: request.action)
+
+                    if let resourceID = request.resourceID {
+                        LabeledContent("Resource ID", value: resourceID)
+                    }
+                }
+
+                if !request.details.isEmpty {
+                    Section("Details:") {
+                        ForEach(Array(request.details.enumerated()), id: \.offset) { _, detail in
+                            LabeledContent(detail.label, value: detail.value)
+                        }
+                    }
+                }
+
+                if request.isDestructive {
+                    Section {
+                        Label(
+                            "This action deletes data and cannot be undone.",
+                            systemImage: "exclamationmark.triangle.fill"
+                        )
+                        .foregroundStyle(.red)
+                    }
+                }
+            }
+            .textSelection(.enabled)
+            .navigationTitle("Proposed tool action")
+#if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+#endif
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Deny", role: .cancel, action: deny)
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    if request.isDestructive {
+                        Button("Approve", role: .destructive, action: approve)
+                    } else {
+                        Button("Approve", action: approve)
+                    }
+                }
+            }
+        }
+        .interactiveDismissDisabled()
+#if os(iOS)
+        .presentationDetents([.medium, .large])
+#else
+        .frame(minWidth: 420, minHeight: 360)
+#endif
+    }
+}

--- a/Foundation Lab/Views/Runs/RunToolsSection.swift
+++ b/Foundation Lab/Views/Runs/RunToolsSection.swift
@@ -20,8 +20,8 @@ struct RunToolsSection: View {
                     Label {
                         VStack(alignment: .leading, spacing: Spacing.xSmall) {
                             Text(LocalizedStringKey(tool.displayName))
-                            Text(tool.toolName)
-                                .font(.subheadline.monospaced())
+                            Text(tool.summary)
+                                .font(.subheadline)
                                 .foregroundStyle(.secondary)
                         }
                     } icon: {

--- a/FoundationLabCore/Package.swift
+++ b/FoundationLabCore/Package.swift
@@ -33,7 +33,8 @@ let package = Package(
             name: "FoundationLabCoreTests",
             dependencies: [
                 "FoundationLabCore",
-                .product(name: "FoundationModelsKit", package: "FoundationModelsKit")
+                .product(name: "FoundationModelsKit", package: "FoundationModelsKit"),
+                .product(name: "FoundationModelsTools", package: "FoundationModelsKit")
             ]
         )
     ]

--- a/FoundationLabCore/Sources/FoundationLabCore/Models/FoundationLabBuiltInTool.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Models/FoundationLabBuiltInTool.swift
@@ -85,50 +85,86 @@ public enum FoundationLabBuiltInTool: String, CaseIterable, Codable, Hashable, S
         }
     }
 
-    public var toolName: String {
+    public var toolNames: [String] {
         switch self {
         case .weather:
-            "getWeather"
+            ["getWeather"]
         case .web:
-            "searchWeb"
+            ["searchWeb"]
         case .contacts:
-            "manageContacts"
+            ["manageContacts"]
         case .calendar:
-            "manageCalendar"
+            ["readCalendar", "mutateCalendar"]
         case .reminders:
-            "manageReminders"
+            ["readReminders", "mutateReminders"]
         case .location:
-            "accessLocation"
+            ["accessLocation"]
         case .health:
-            "accessHealth"
+            ["accessHealth"]
         case .music:
-            "controlMusic"
+            ["controlMusic"]
         case .webMetadata:
-            "getWebMetadata"
+            ["getWebMetadata"]
         }
     }
 
     @MainActor
-    public func makeTool() -> any Tool {
+    public func makeTools(
+        mutationConfirmation: (any ToolMutationConfirming)? = nil
+    ) -> [any Tool] {
         switch self {
         case .weather:
-            WeatherTool()
+            [WeatherTool()]
         case .web:
-            Search1WebSearchTool()
+            [Search1WebSearchTool()]
         case .contacts:
-            ContactsTool()
+            [ContactsTool()]
         case .calendar:
-            CalendarTool()
+            calendarTools(mutationConfirmation: mutationConfirmation)
         case .reminders:
-            RemindersTool()
+            reminderTools(mutationConfirmation: mutationConfirmation)
         case .location:
-            LocationTool()
+            [LocationTool()]
         case .health:
-            HealthTool()
+            [HealthTool()]
         case .music:
-            MusicTool()
+            [MusicTool()]
         case .webMetadata:
-            WebMetadataTool()
+            [WebMetadataTool()]
         }
+    }
+
+    @MainActor
+    private func calendarTools(
+        mutationConfirmation: (any ToolMutationConfirming)?
+    ) -> [any Tool] {
+        let service = EventKitCalendarService()
+        var tools: [any Tool] = [CalendarReadTool(service: service)]
+        if let mutationConfirmation {
+            tools.append(
+                CalendarMutationTool(
+                    service: service,
+                    confirmation: mutationConfirmation
+                )
+            )
+        }
+        return tools
+    }
+
+    @MainActor
+    private func reminderTools(
+        mutationConfirmation: (any ToolMutationConfirming)?
+    ) -> [any Tool] {
+        let service = EventKitRemindersService()
+        var tools: [any Tool] = [RemindersReadTool(service: service)]
+        if let mutationConfirmation {
+            tools.append(
+                RemindersMutationTool(
+                    service: service,
+                    confirmation: mutationConfirmation
+                )
+            )
+        }
+        return tools
     }
 }

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsCalendarQuerier.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsCalendarQuerier.swift
@@ -28,9 +28,10 @@ public struct FoundationModelsCalendarQuerier: CalendarQuerying {
         Use this information when interpreting relative dates like "today" or "tomorrow".
         """
 
+        let service = EventKitCalendarService()
         return try await toolInvoker.respond(
             to: query,
-            using: CalendarTool(),
+            using: CalendarReadTool(service: service),
             systemPrompt: FoundationModelsPromptSupport.combinedSystemPrompt([
                 request.systemPrompt,
                 contextualInstructions

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsReminderManager.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsReminderManager.swift
@@ -4,8 +4,20 @@ import FoundationModelsKit
 
 public struct FoundationModelsReminderManager: ReminderManaging {
     private let toolInvoker: FoundationModelsToolInvoker
+    private let mutationConfirmation: any ToolMutationConfirming
 
     public init(toolInvoker: FoundationModelsToolInvoker = FoundationModelsToolInvoker()) {
+        self.init(
+            mutationConfirmation: DenyingToolMutationConfirmation(),
+            toolInvoker: toolInvoker
+        )
+    }
+
+    public init(
+        mutationConfirmation: any ToolMutationConfirming,
+        toolInvoker: FoundationModelsToolInvoker = FoundationModelsToolInvoker()
+    ) {
+        self.mutationConfirmation = mutationConfirmation
         self.toolInvoker = toolInvoker
     }
 
@@ -33,9 +45,16 @@ public struct FoundationModelsReminderManager: ReminderManaging {
                 )
         ])
 
+        let service = EventKitRemindersService()
         return try await toolInvoker.respond(
             to: prompt,
-            using: RemindersTool(),
+            using: [
+                RemindersReadTool(service: service),
+                RemindersMutationTool(
+                    service: service,
+                    confirmation: mutationConfirmation
+                )
+            ],
             systemPrompt: instructions,
             modelUseCase: request.modelUseCase,
             guardrails: request.guardrails
@@ -97,8 +116,7 @@ public struct FoundationModelsReminderManager: ReminderManaging {
         Current date and time: \(formattedDate)
         Time zone: \(timeZone.identifier) (\(timeZoneName))
         When creating reminders, consider the current date and time zone context.
-        Always execute tool calls directly without asking for confirmation or permission from the user.
-        If you need to create a reminder, call the RemindersTool immediately with the appropriate parameters.
+        Call the reminder mutation tool when the request needs a change. The host app will review the exact mutation.
         IMPORTANT: When setting due dates, you MUST format them as 'yyyy-MM-dd HH:mm:ss' (24-hour format).
         Examples: '2025-01-15 17:00:00' for tomorrow at 5 PM, '2025-01-16 09:30:00' for day after tomorrow at 9:30 AM.
         Calculate the exact date and time based on the current date and time provided above.
@@ -118,8 +136,14 @@ public struct FoundationModelsReminderManager: ReminderManaging {
         You are a helpful assistant that creates reminders based on structured input.
         Current date and time: \(formattedDate)
         Time zone: \(timeZone.identifier) (\(timeZoneName))
-        Always execute the RemindersTool directly with the provided information.
+        Call the reminder mutation tool with the provided information. The host app will review the exact mutation.
         Format due dates as 'yyyy-MM-dd HH:mm:ss' (24-hour format).
         """
+    }
+}
+
+private struct DenyingToolMutationConfirmation: ToolMutationConfirming {
+    func confirmation(for request: ToolMutationRequest) async throws -> ToolMutationDecision {
+        .denied(reason: "The host app did not provide a mutation confirmation surface.")
     }
 }

--- a/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsToolInvoker.swift
+++ b/FoundationLabCore/Sources/FoundationLabCore/Providers/FoundationModelsToolInvoker.swift
@@ -13,6 +13,24 @@ public struct FoundationModelsToolInvoker: Sendable {
         guardrails: FoundationModelGuardrails? = nil,
         generationOptions: FoundationModelGenerationOptions? = nil
     ) async throws -> FoundationModelTextGenerationResult {
+        try await respond(
+            to: prompt,
+            using: [tool],
+            systemPrompt: systemPrompt,
+            modelUseCase: modelUseCase,
+            guardrails: guardrails,
+            generationOptions: generationOptions
+        )
+    }
+
+    public func respond(
+        to prompt: String,
+        using tools: [any Tool],
+        systemPrompt: String? = nil,
+        modelUseCase: FoundationModelUseCase = .general,
+        guardrails: FoundationModelGuardrails? = nil,
+        generationOptions: FoundationModelGenerationOptions? = nil
+    ) async throws -> FoundationModelTextGenerationResult {
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPrompt.isEmpty else {
             throw FoundationLabCoreError.invalidRequest("Missing prompt")
@@ -28,11 +46,11 @@ public struct FoundationModelsToolInvoker: Sendable {
            !systemPrompt.isEmpty {
             session = LanguageModelSession(
                 model: model,
-                tools: [tool],
+                tools: tools,
                 instructions: Instructions(systemPrompt)
             )
         } else {
-            session = LanguageModelSession(model: model, tools: [tool])
+            session = LanguageModelSession(model: model, tools: tools)
         }
 
         let responseContent: String

--- a/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabExperimentTests.swift
+++ b/FoundationLabCore/Tests/FoundationLabCoreTests/FoundationLabExperimentTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import XCTest
 import FoundationModelsKit
+import FoundationModelsTools
 @testable import FoundationLabCore
 
 final class FoundationLabExperimentTests: XCTestCase {
@@ -44,9 +45,23 @@ final class FoundationLabExperimentTests: XCTestCase {
         XCTAssertEqual(Set(tools.map(\.displayName)).count, tools.count)
         XCTAssertEqual(Set(tools.map(\.summary)).count, tools.count)
         XCTAssertEqual(Set(tools.map(\.systemImage)).count, tools.count)
-        XCTAssertEqual(Set(tools.map(\.toolName)).count, tools.count)
+        XCTAssertEqual(
+            Set(tools.flatMap(\.toolNames)).count,
+            tools.flatMap(\.toolNames).count
+        )
         XCTAssertTrue(tools.allSatisfy { !$0.summary.isEmpty })
-        XCTAssertEqual(tools.map { $0.makeTool().name }, tools.map(\.toolName))
+        XCTAssertEqual(
+            tools.flatMap { $0.makeTools().map(\.name) },
+            tools.flatMap(\.toolNames).filter { !$0.hasPrefix("mutate") }
+        )
+
+        let confirmation = ToolMutationConfirmationHandler { _ in .denied() }
+        XCTAssertEqual(
+            tools.flatMap {
+                $0.makeTools(mutationConfirmation: confirmation).map(\.name)
+            },
+            tools.flatMap(\.toolNames)
+        )
     }
 
     func testAsNewExperimentRefreshesIdentityAndTimestampsOnly() {

--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,8 @@ let package = Package(
             name: "FoundationLabCoreTests",
             dependencies: [
                 "FoundationLabCore",
-                .product(name: "FoundationModelsKit", package: "FoundationModelsKit")
+                .product(name: "FoundationModelsKit", package: "FoundationModelsKit"),
+                .product(name: "FoundationModelsTools", package: "FoundationModelsKit")
             ],
             path: "FoundationLabCore/Tests/FoundationLabCoreTests"
         )


### PR DESCRIPTION
## Summary

- replace deprecated combined Calendar and Reminders tools with separate read and mutation tools
- add a cancellation-safe, queued Playground approval coordinator so model-authored arguments cannot approve their own side effects
- present the exact tool, action, details, resource identifier, and destructive warning in a native review sheet
- route the Manage Reminders App Intent through App Intents system confirmation
- keep Core callers fail-closed when the host app does not provide a confirmation surface
- export safe sample code that denies mutations until the developer connects app-owned confirmation UI

This is stacked on #211 because it uses FoundationModelsKit 3.0.1 mutation-safety APIs. It can be retargeted to main after #211 lands.

## Validation

- Xcode 27 Beta 5: swift test (54 XCTest cases, 4 expected runtime skips; 5 Swift Testing cases)
- Xcode 26.6 RC 2: swift test (50 XCTest cases; 5 Swift Testing cases)
- Xcode 27 Beta 5: generic macOS and iOS Simulator builds
- Xcode 26.6 RC 2: generic macOS and iOS Simulator builds
- swiftlint lint --strict --config .swiftlint.yml (276 app files, 0 violations)
- all five new user-facing strings translated in ten locales
- localization JSON and git diff checks

## Safety behavior

Read-only tools remain available without a confirmer. Calendar and Reminders mutation tools are registered only when the host supplies one. Dismissal and explicit denial both deny the current request; generation cancellation resumes and cancels all suspended confirmations.