### PR TITLE
Restore unreachable Xcode 27 labs in Library

### DIFF
--- a/Foundation Lab/Models/ExampleType.swift
+++ b/Foundation Lab/Models/ExampleType.swift
@@ -45,29 +45,51 @@ enum ExampleType: String, CaseIterable, Identifiable {
 extension ExampleType {
     var id: String { rawValue }
 
-    static let xcode27Examples: [ExampleType] = [
-        .modelRuntime,
-        .contextWindowInspector,
-        .privateCloudCompute,
-        .imageInputPlayground,
-        .usagePerformanceTrace,
-        .toolCallingModeLab,
-        .riskyToolConfirmation,
-        .foundationModelsSecurityPlayground,
-        .toolCallTrajectoryViewer,
-        .dynamicProfileBuilder,
-        .reasoningLevelComparison,
-        .transcriptExplorer,
-        .agentFlowInspector,
-        .historyTransformLab,
-        .modelRouterDashboard,
-        .contextBudgetVisualizer,
-        .geminiVideoInput,
-        .spotlightRAGExplorer,
-        .providerBridgeWalkthrough,
-        .evaluationsLab,
-        .fmCLIPythonPlayground
+    static let xcode27Sections: [Xcode27ExampleSection] = [
+        Xcode27ExampleSection(
+            track: .contextAndRuntime,
+            examples: [
+                .modelRuntime,
+                .contextWindowInspector,
+                .privateCloudCompute,
+                .imageInputPlayground,
+                .usagePerformanceTrace
+            ]
+        ),
+        Xcode27ExampleSection(
+            track: .buildWithTools,
+            examples: [
+                .toolCallingModeLab,
+                .riskyToolConfirmation,
+                .foundationModelsSecurityPlayground,
+                .toolCallTrajectoryViewer
+            ]
+        ),
+        Xcode27ExampleSection(
+            track: .workflows,
+            examples: [
+                .dynamicProfileBuilder,
+                .reasoningLevelComparison,
+                .transcriptExplorer,
+                .agentFlowInspector,
+                .historyTransformLab,
+                .modelRouterDashboard,
+                .contextBudgetVisualizer,
+                .evaluationsLab,
+                .fmCLIPythonPlayground
+            ]
+        ),
+        Xcode27ExampleSection(
+            track: .appliedProjects,
+            examples: [
+                .geminiVideoInput,
+                .spotlightRAGExplorer,
+                .providerBridgeWalkthrough
+            ]
+        )
     ]
+
+    static let xcode27Examples = xcode27Sections.flatMap(\.examples)
 
     var title: String {
         switch self {
@@ -270,6 +292,13 @@ extension ExampleType {
         }
     }
 
+}
+
+struct Xcode27ExampleSection: Identifiable {
+    let track: ExperimentTrack
+    let examples: [ExampleType]
+
+    var id: ExperimentTrack { track }
 }
 
 // MARK: - Language Example Enum

--- a/Foundation Lab/Views/Library/ExperimentLibraryCatalogView.swift
+++ b/Foundation Lab/Views/Library/ExperimentLibraryCatalogView.swift
@@ -66,45 +66,9 @@ struct ExperimentLibraryCatalogView: View {
 
     @ViewBuilder
     private var xcode27Sections: some View {
-        exampleSection(
-            ExperimentTrack.contextAndRuntime.title,
-            examples: [
-                .modelRuntime,
-                .contextWindowInspector,
-                .privateCloudCompute,
-                .imageInputPlayground,
-                .usagePerformanceTrace
-            ]
-        )
-        exampleSection(
-            ExperimentTrack.buildWithTools.title,
-            examples: [
-                .toolCallingModeLab,
-                .riskyToolConfirmation,
-                .foundationModelsSecurityPlayground,
-                .toolCallTrajectoryViewer
-            ]
-        )
-        exampleSection(
-            ExperimentTrack.workflows.title,
-            examples: [
-                .dynamicProfileBuilder,
-                .reasoningLevelComparison,
-                .transcriptExplorer,
-                .agentFlowInspector,
-                .historyTransformLab,
-                .modelRouterDashboard,
-                .contextBudgetVisualizer
-            ]
-        )
-        exampleSection(
-            ExperimentTrack.appliedProjects.title,
-            examples: [
-                .geminiVideoInput,
-                .spotlightRAGExplorer,
-                .providerBridgeWalkthrough
-            ]
-        )
+        ForEach(ExampleType.xcode27Sections) { section in
+            exampleSection(section.track.title, examples: section.examples)
+        }
     }
 
     private func exampleSection(


### PR DESCRIPTION
## Summary
- derive the Xcode 27 Library sections and flat example list from one canonical grouping
- restore navigation links for the existing Evaluations and fm CLI & Python labs
- keep the catalog ordering and track labels consistent without duplicating arrays in the view

## Why
The two labs were implemented and included in `ExampleType.xcode27Examples`, but `ExperimentLibraryCatalogView` maintained a second hand-written list that omitted them. A passing build therefore shipped unreachable features.

This PR is stacked on #211 so its Xcode 27 build uses FoundationModelsKit 3.0.1. The diff against that base is only the catalog repair.

## Validation
- `swiftlint lint --strict --config .swiftlint.yml` (275 files, 0 violations)
- Xcode 26.6 RC2 macOS build
- Xcode 26.6 RC2 iOS Simulator build
- Xcode 27 beta 5 macOS build
- Xcode 27 beta 5 iOS Simulator build
- `git diff --check`