### PR TITLE
[codex] Update Foundation Models interface for Xcode 27 beta 6

### DIFF
--- a/fmf.md
+++ b/fmf.md
@@ -1,11 +1,27 @@
 ## Xcode 27 Foundation Models API Delta
 
-Source: Xcode 27.0 beta 5 (build `27A5237l`) FoundationModels Swift
+Source: Xcode 27.0 beta 6 (build `27A5252f`) FoundationModels Swift
 interface (`9705` lines), synthesized from the iOS SDK public module surface
 with an iOS 26.0 deployment target.
 
 This section records the new public API shape found in Xcode 27. The raw Swift
-interface reference below is refreshed from the beta 5 SDK.
+interface reference below is refreshed from the beta 6 SDK.
+
+### Beta 6 changes
+
+Compared with the Xcode 27 beta 5 SDK interface:
+
+- The public Foundation Models interface is unchanged. Both SDKs synthesize to
+  9,705 lines, and their normalized interface content is identical.
+- The Foundation Models documentation adds “Running a Core AI model in a
+  Foundation Models session.” It uses `CoreAILanguageModel` from Apple's
+  external `coreai-models` package with `LanguageModelSession`; it does not add
+  a declaration to the Foundation Models SDK.
+
+Apple's Xcode 27 beta 6 release notes contain no Foundation Models API entry.
+The installed Xcode 27 documentation archive (`10M13878`) contains the Core AI
+guide, while the installed SDK remains the source of truth for the public
+interface result.
 
 ### Beta 5 changes
 


### PR DESCRIPTION
## What changed

- Compared the Foundation Models public interface in Xcode 27 beta 6 (build `27A5252f`) with beta 5 using an iOS 26.0 deployment target. Both synthesize to 9,705 lines and match after normalizing generator whitespace.
- Added beta 6 notes for the new Core AI model guide. `CoreAILanguageModel` comes from Apple's separate `coreai-models` package; beta 6 adds no declaration to the Foundation Models SDK. The check covered Developer Documentation `10M13878`, Apple's live DocC JSON, the Xcode 27 beta 6 release notes, and the installed SDK interface.

## Developer impact

Beta 6 needs no Foundation Models source migration. The new guide shows how a Core AI model can conform to `LanguageModel` and run through `LanguageModelSession`, but apps must add Apple's `coreai-models` package and target iOS 27 or macOS 27 for that path.

## Validation

- `git diff --check` passes.
- SwiftLint strict mode passes with zero violations across 287 files.
- `swift test` passes: 54 XCTest cases (4 skipped) plus 5 Swift Testing cases.
- The generic macOS and iOS Simulator builds pass with Xcode 27 beta 6.
- Xcode 27 beta 6 and its iOS 27 beta 6 simulator are installed; the Ready runtime is `24A5423a`.
